### PR TITLE
fix: fixed chinese path related problems v2(issues#24)

### DIFF
--- a/src/legacy/main/Loader.cpp
+++ b/src/legacy/main/Loader.cpp
@@ -42,16 +42,16 @@ void LoadDepends() {
                 if (!content) throw("Fail to open plugin file!");
                 depends.emplace(path, *content);
                 lse::getSelfPluginInstance().getLogger().info(
-                    "llse.loader.loadDepends.success"_tr(i.path().filename().string())
+                    "llse.loader.loadDepends.success"_tr(ll::string_utils::u8str2str(i.path().filename().u8string()))
                 );
             } catch (std::exception e) {
                 lse::getSelfPluginInstance().getLogger().warn(
-                    "llse.loader.loadDepends.fail"_tr(i.path().filename().string())
+                    "llse.loader.loadDepends.fail"_tr(ll::string_utils::u8str2str(i.path().filename().u8string()))
                 );
                 lse::getSelfPluginInstance().getLogger().warn(ll::string_utils::tou8str(e.what()));
             } catch (...) {
                 lse::getSelfPluginInstance().getLogger().warn(
-                    "llse.loader.loadDepends.fail"_tr(i.path().filename().string())
+                    "llse.loader.loadDepends.fail"_tr(ll::string_utils::u8str2str(i.path().filename().u8string()))
                 );
             }
         }

--- a/src/legacy/main/PluginManager.cpp
+++ b/src/legacy/main/PluginManager.cpp
@@ -54,7 +54,7 @@ bool PluginManager::loadPlugin(const std::string& fileOrDirPath, bool isHotLoad,
     }
 
     // Get bacis information
-    bool   isPluginPackage = std::filesystem::is_directory(fileOrDirPath);
+    bool isPluginPackage = std::filesystem::is_directory(ll::string_utils::str2wstr(fileOrDirPath));
     string backendType     = getPluginBackendType(fileOrDirPath);
     if (backendType.empty()) {
         lse::getSelfPluginInstance().getLogger().error(fileOrDirPath + " is not a valid plugin path!");

--- a/src/lse/Entry.cpp
+++ b/src/lse/Entry.cpp
@@ -150,10 +150,10 @@ auto loadBaseLib(ll::plugin::NativePlugin& self) -> bool {
     auto content = ll::file_utils::readFile(path);
 
     if (!content) {
-        throw std::runtime_error(fmt::format("failed to read {}", path.string()));
+        throw std::runtime_error(fmt::format("failed to read {}", ll::string_utils::u8str2str(path.u8string())));
     }
 
-    depends.emplace(path.string(), *content);
+    depends.emplace(ll::string_utils::u8str2str(path.u8string()), *content);
 
     return true;
 }

--- a/src/lse/PluginManager.cpp
+++ b/src/lse/PluginManager.cpp
@@ -67,10 +67,10 @@ auto PluginManager::load(ll::plugin::Manifest manifest) -> bool {
 
         logger.info("loading plugin {}", manifest.name);
 
-        auto pluginDir = std::filesystem::canonical(ll::plugin::getPluginsRoot() / manifest.name);
-        auto entryPath = pluginDir / manifest.entry;
+        auto pluginDir = std::filesystem::canonical(ll::plugin::getPluginsRoot() / ll::string_utils::str2wstr(manifest.name));
+        auto entryPath = pluginDir / ll::string_utils::str2wstr(manifest.entry);
 
-        if (!::PluginManager::loadPlugin(entryPath.string(), false, true)) {
+        if (!::PluginManager::loadPlugin(ll::string_utils::u8str2str(entryPath.u8string()), false, true)) {
             throw std::runtime_error(fmt::format("failed to load plugin {}", manifest.name));
         }
         return true;

--- a/src/lse/PluginMigration.cpp
+++ b/src/lse/PluginMigration.cpp
@@ -31,7 +31,7 @@ auto migratePlugin(const std::filesystem::path& path) -> void {
 
     auto& logger = self.getLogger();
 
-    logger.info("migrating legacy plugin at {}", path.string());
+    logger.info("migrating legacy plugin at {}", ll::string_utils::u8str2str(path.u8string()));
 
     auto& pluginManager = getPluginManager();
 
@@ -43,13 +43,13 @@ auto migratePlugin(const std::filesystem::path& path) -> void {
 
     if (std::filesystem::exists(pluginDir / pluginFileName)) {
         throw std::runtime_error(
-            fmt::format("failed to migrate legacy plugin at {}: {} already exists", path.string(), pluginDir.string())
+            fmt::format("failed to migrate legacy plugin at {}: {} already exists", ll::string_utils::u8str2str(path.u8string()), ll::string_utils::u8str2str(pluginDir.u8string()))
         );
     }
 
     if (!std::filesystem::exists(pluginDir)) {
         if (!std::filesystem::create_directory(pluginDir)) {
-            throw std::runtime_error(fmt::format("failed to create directory {}", pluginDir.string()));
+            throw std::runtime_error(fmt::format("failed to create directory {}", ll::string_utils::u8str2str(pluginDir.u8string())));
         }
     }
 
@@ -57,8 +57,8 @@ auto migratePlugin(const std::filesystem::path& path) -> void {
     std::filesystem::rename(path, pluginDir / pluginFileName);
 
     ll::plugin::Manifest manifest{
-        .entry = pluginFileName.string(),
-        .name  = pluginFileBaseName.string(),
+        .entry = ll::string_utils::u8str2str(pluginFileName.u8string()),
+        .name  = ll::string_utils::u8str2str(pluginFileBaseName.u8string()),
         .type  = pluginType,
         .dependencies =
             std::unordered_set<ll::plugin::Dependency>{

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,70 +1,49 @@
 add_rules("mode.debug", "mode.release")
 
 add_repositories("liteldev-repo https://github.com/LiteLDev/xmake-repo.git")
+
 add_requires(
     "demangler v2.0.0",
     "dyncall 1.4",
     "fmt 10.1.1",
     "legacymoney 0.2.0",
     "legacyparticleapi 0.2.0",
+    "legacyremotecall 0.2.0",
     "levilamina 0.7.2",
     "lightwebsocketclient 1.0.0",
     "magic_enum v0.9.0",
+    "more-events develop",
     "nlohmann_json 3.11.2",
     "openssl 1.1.1-w",
     "simpleini v4.19",
     "sqlite3 3.43.0+200",
-    "toml++ v3.4.0",
-    "legacyremotecall 0.2.0"
+    "toml++ v3.4.0"
 )
-add_requires("cpp-httplib v0.14.0", {configs={shared=false, ssl=true, zlib=true}})
-add_requires("scriptx", {configs={backend=get_config("backend")}})
+add_requires("cpp-httplib v0.14.0", {configs={ssl=true, zlib=true}})
 
-set_runtimes("MD") -- For compatibility with the /MD build configuration of ScriptX.
+if is_config("backend", "lua") then
+    add_requires("scriptx 3.2.0", {configs={backend="Lua"}})
+
+elseif is_config("backend", "quickjs") then
+    add_requires("scriptx 3.2.0", {configs={backend="QuickJs"}})
+
+end
+
+if not has_config("vs_runtime") then
+    set_runtimes("MD")
+end
 
 option("backend")
     set_default("lua")
     set_values("lua", "quickjs")
 
-package("quickjs")
-    add_urls("https://github.com/LiteLDev/ScriptX/releases/download/prebuilt/quickjs.zip")
-    add_versions("latest", "af0c38b0cf80aa1deb58e727e408477fffcc6f5f57da537dffc335861d652ed0")
+package("more-events")
+    add_urls("https://github.com/LiteLDev/MoreEvents.git")
+
+    add_deps("levilamina 0.7.2")
 
     on_install(function (package)
-        os.cp("*", package:installdir())
-    end)
-
-package("scriptx")
-    add_configs("backend", {default = "lua", values = {"lua", "quickjs"}})
-    add_includedirs(
-        "src/include/"
-    )
-    add_urls("https://github.com/LiteLDev/ScriptX/releases/download/prebuilt/scriptx.zip")
-    add_versions("latest", "dd5fb21370a59f38e4c33f48f4a6eecb25692283e4d49bbee983453e05b128ab")
-
-    on_install(function (package)
-        os.cp("*", package:installdir())
-    end)
-
-    on_load(function (package)
-        local backend = package:config("backend")
-
-        local deps = {
-            lua = "lua v5.4.6",
-            quickjs = "quickjs",
-        }
-
-        local scriptx_backends = {
-            lua = "Lua",
-            quickjs = "QuickJs",
-        }
-
-        print("Using ScriptX config: backend=" .. backend .. ", scriptx_backend=" .. scriptx_backends[backend])
-        
-        package:add("defines", "SCRIPTX_BACKEND=" .. scriptx_backends[backend])
-        package:add("defines", "SCRIPTX_BACKEND_TRAIT_PREFIX=../backend/" .. scriptx_backends[backend] .. "/trait/Trait")
-        package:add("deps", deps[backend])
-        package:add("links", "scriptx_" .. scriptx_backends[backend])
+        import("package.tools.xmake").install(package)
     end)
 
 target("legacy-script-engine")
@@ -92,15 +71,16 @@ target("legacy-script-engine")
         "fmt",
         "legacymoney",
         "legacyparticleapi",
+        "legacyremotecall",
         "levilamina",
         "lightwebsocketclient",
         "magic_enum",
+        "moreevents",
         "nlohmann_json",
         "scriptx",
         "simpleini",
         "sqlite3",
-        "toml++",
-        "legacyremotecall"
+        "toml++"
     )
     add_shflags(
         "/DELAYLOAD:bedrock_server.dll" -- To use forged symbols of SymbolProvider.
@@ -134,3 +114,4 @@ target("legacy-script-engine")
         
         plugin_packer.pack_plugin(target,plugin_define)
     end)
+


### PR DESCRIPTION
本PR修复[issues#24](https://github.com/LiteLDev/LegacyScriptEngine/issues/24#issuecomment-1936946938)

下面是解释说明：

# 插件含中文路径名问题

而在本项目的加载逻辑中：
(/src/lse/PluginManager.cpp:73)
```cpp
        if (!::PluginManager::loadPlugin(entryPath.string(), false, true)) {
            throw std::runtime_error(fmt::format("failed to load plugin {}", manifest.name));
        }
```
把它替换成
```cpp
        if (!::PluginManager::loadPlugin(ll::string_utils::u8str2str(entryPath.u8string()), false, true)) {
            throw std::runtime_error(fmt::format("failed to load plugin {}", manifest.name));
        }
```
然后报错编码错误，问题来自：
(/src/legacy/main/PluginManager.cpp:57)
```cpp
    bool   isPluginPackage = std::filesystem::is_directory(fileOrDirPath);
```
直接使用了string去构造path，替换为
```cpp
    bool isPluginPackage = std::filesystem::is_directory(ll::string_utils::str2wstr(fileOrDirPath));
```
问题就解决了

# 插件名称为中文时的问题

如果插件名称为中文，需要migratePlugin时
```
ERROR IN LOGGER API:
C++ Exception: std::runtime_error, from <LeviLamina>:
invalid utf8
migrating legacy plugin at plugins/聊天拦截插件.js
16:17:09.417 ERROR [LeviLamina] C++ Exception: nlohmann::json_abi_v3_11_2::detail::type_error, from <legacy-script-engine-quickjs>:
16:17:09.417 ERROR [LeviLamina] [json.exception.type_error.316] invalid UTF-8 byte at index 0: 0xC1
```
会出现两个错误，第一个是log api遇到了非u8字符
第二个是生成json时遇到了非u8字符
定位问题在：
(/src/lse/PluginMigration.cpp:34)
```cpp
logger.info("migrating legacy plugin at {}", path.string());
```
(/src/lse/PluginMigration.cpp:59)
```cpp
        .entry = pluginFileName.string(),
        .name  = pluginFileBaseName.string(),
```
替换为：
```cpp
logger.info("migrating legacy plugin at {}", ll::string_utils::u8str2str(path.u8string()));
```
```cpp
        .entry = ll::string_utils::u8str2str(pluginFileName.u8string()),
        .name  = ll::string_utils::u8str2str(pluginFileBaseName.u8string()),
```
除此之外这个文件下的抛出异常代码也没有正确处理编码，这里省略不诉
然后在加载插件前还有编码异常的代码：
(/src/lse/PluginManager.cpp:70)
```cpp
auto pluginDir = std::filesystem::canonical(ll::plugin::getPluginsRoot() / manifest.name);
auto entryPath = pluginDir / manifest.entry;
```
manifest里面的成员都是装着utf8的string，path无法把string正确识别为utf8进行构造，需要改成wstr：
```cpp
auto pluginDir = std::filesystem::canonical(ll::plugin::getPluginsRoot() / ll::string_utils::str2wstr(manifest.name));
auto entryPath = pluginDir / ll::string_utils::str2wstr(manifest.entry);
```

# 其它的编码问题

因为ll的架构设计，所有使用stlpath.string()的地方都是有BUG的，应该换成：ll::string_utils::u8str2str(stlpath.u8string())
此外，所有重载为path的/运算符都应该检查右边是否为纯英语，否则必须转为wstr，不过目前没在其它地方发现有这个的问题

stlpath.string()导致的问题清单
```
src\legacy\main\Loader.cpp:
  44                  lse::getSelfPluginInstance().getLogger().info(
  45:                     "llse.loader.loadDepends.success"_tr(i.path().filename().string())
  46                  );

  48                  lse::getSelfPluginInstance().getLogger().warn(
  49:                     "llse.loader.loadDepends.fail"_tr(i.path().filename().string())
  50                  );

  53                  lse::getSelfPluginInstance().getLogger().warn(
  54:                     "llse.loader.loadDepends.fail"_tr(i.path().filename().string())
  55                  );

src\lse\Entry.cpp:
  152      if (!content) {
  153:         throw std::runtime_error(fmt::format("failed to read {}", path.string()));
  154      }
  155  
  156:     depends.emplace(path.string(), *content);
  157  
```
具体的修复过程就不在赘述了，请直接看文件变动

# 验证BUG是否修复

## 本地编译测试

在插件目录下创建一个中文名的插件和一个英文名的插件，同时BDS放置在英文目录下测试

migrating正常：

![image](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/fe58f009-492e-4653-aad0-b1612b2eb93f)

关闭后重启，加载正常：

![image-1](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/69b21b77-1998-455c-8ba3-e27a19ed51d0)

然后更换到中文路径下重新实验：

migrating正常：

![image-2](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/9d4a348d-c58d-4b35-bc1e-a13e2c26b1a1)

关闭后重启，加载正常：

![image-3](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/bec87f47-6535-41d2-a96e-e4aecd2385d3)

## Github Action编译测试

![image-4](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/2b9dba94-7ac8-435d-a3ec-9ff866bdea13)

在插件目录下创建一个中文名的插件和一个英文名的插件，同时BDS放置在英文目录下测试

migrating正常：

![image-5](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/3ae66645-cd52-4332-a74a-26cc5c805107)

关闭后重启，加载正常：

![image-6](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/d5d7be68-4f47-4f19-8a5d-2be54568fc75)

然后更换到中文路径下重新实验：

migrating正常：

![image-7](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/ce83c398-b533-4363-a91d-b32dcfb33bb5)

关闭后重启，加载正常：

![image-8](https://github.com/LiteLDev/LegacyScriptEngine/assets/98995022/47c7e091-8b03-4005-8d51-3a5bf45936f0)

# 所有测试均通过

备注：因为xmake依赖的库被修改了，所以说我同步了develop分支的xmake.lua，否则无法完成Github Action编译测试