### PR TITLE
fix: fix getAllTags

### DIFF
--- a/src/legacy/api/EntityAPI.cpp
+++ b/src/legacy/api/EntityAPI.cpp
@@ -1357,11 +1357,9 @@ Local<Value> EntityClass::getAllTags(const Arguments& args) {
         if (!entity) return Local<Value>();
 
         Local<Array> arr = Array::newArray();
-        CompoundTag  tag = CompoundTag();
-        entity->save(tag);
-        tag.at("tags").get<ListTag>().forEachCompoundTag([&arr](const CompoundTag& tag) {
-            arr.add(String::newString(tag.toString()));
-        });
+        for (auto tag : entity->getTags()) {
+            arr.add(String::newString(tag));
+        }
         return arr;
     }
     CATCH("Fail in getAllTags!");

--- a/src/legacy/api/PlayerAPI.cpp
+++ b/src/legacy/api/PlayerAPI.cpp
@@ -2917,11 +2917,9 @@ Local<Value> PlayerClass::getAllTags(const Arguments& args) {
         if (!player) return Local<Value>();
 
         Local<Array> arr = Array::newArray();
-        CompoundTag  tag = CompoundTag();
-        player->save(tag);
-        tag.at("Tags").get<ListTag>().forEachCompoundTag([&arr](const CompoundTag& tag) {
-            arr.add(String::newString(tag.toString()));
-        });
+        for (auto tag : player->getTags()) {
+            arr.add(String::newString(tag));
+        }
         return arr;
     }
     CATCH("Fail in getAllTags!");


### PR DESCRIPTION
## What does this PR do?

修复 getAllTags 会返回空数组，原本调用的 forEachCompoundTag 似乎并不能遍历 ListTag 的元素，而且获取玩家 NBT 性能也不太行，实际上只要调用 MCAPI getTags 就行了。

## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows [LeviLamina C++ Style Guide](https://github.com/LiteLDev/LeviLamina/wiki/CPP-Style-Guide)
- [x] You have tested all functions
- [x] You have not used code without license
- [ ] You have added statement for third-party code
